### PR TITLE
Add Integer type to Schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,10 @@ name = "gemini-rs"
 version = "1.0.0"
 edition = "2024"
 license = "MIT"
-authors = ["gvozdvmozgu <gvozdvmozgu@gmail.com>", "Shuflduf <shuflduf@shuflduf.xyz>"]
+authors = [
+    "gvozdvmozgu <gvozdvmozgu@gmail.com>",
+    "Shuflduf <shuflduf@shuflduf.xyz>",
+]
 description = "A library to interact with the Google Gemini API"
 homepage = "https://github.com/Shuflduf/gemini-rs"
 repository = "https://github.com/Shuflduf/gemini-rs"
@@ -12,7 +15,7 @@ keywords = ["ai", "google", "gemini"]
 
 [dependencies]
 futures = "0.3"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
 secrecy = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -18,6 +18,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 (
                     "age".to_string(),
                     Schema {
+                        schema_type: Some(Type::Integer),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "election_percentage".to_string(),
+                    Schema {
                         schema_type: Some(Type::Number),
                         ..Default::default()
                     },

--- a/src/types.rs
+++ b/src/types.rs
@@ -331,6 +331,7 @@ pub enum Type {
     Object,
     Array,
     String,
+    Integer,
     Number,
     Boolean,
 }


### PR DESCRIPTION
Hey, thanks for the great library!

It seems that we're missing the `Integer` type which guarantees that the model doesn't return decimal numbers.

Gemini reference: https://ai.google.dev/api/caching#Schema

Let me know if I need to touch something else, but it seemed quite straightforward!