### PR TITLE
Set Safety Settings for Chat & GenerateContent

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -9,6 +9,7 @@ pub struct Chat<T> {
     model: Box<str>,
     client: Client,
     system_instruction: Option<Box<str>>,
+    safety_settings: Vec<types::SafetySettings>,
     history: Vec<types::Content>,
     config: Option<types::GenerationConfig>,
     phantom: PhantomData<T>,
@@ -20,6 +21,7 @@ impl<T> Chat<T> {
             model: model.into(),
             client: client.clone(),
             system_instruction: None,
+            safety_settings: Vec::new(),
             history: Vec::new(),
             config: None,
             phantom: PhantomData,
@@ -36,6 +38,7 @@ impl<T> Chat<T> {
             model: self.model,
             client: self.client,
             system_instruction: self.system_instruction,
+            safety_settings: self.safety_settings,
             history: self.history,
             config: self.config,
             phantom: PhantomData,
@@ -52,6 +55,10 @@ impl<T> Chat<T> {
 
     pub fn history_mut(&mut self) -> &mut Vec<types::Content> {
         &mut self.history
+    }
+
+    pub fn safety_settings(&mut self, safety_settings: Vec<types::SafetySettings>) {
+        self.safety_settings = safety_settings;
     }
 
     pub fn system_instruction(mut self, instruction: &str) -> Self {
@@ -71,6 +78,7 @@ impl<T> Chat<T> {
         }
 
         generate_content.contents(self.history.clone());
+        generate_content.safety_settings(self.safety_settings.clone());
         generate_content.await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -136,6 +136,10 @@ impl GenerateContent {
         self.body.generation_config = Some(config);
     }
 
+    pub fn safety_settings(&mut self, safety_settings: Vec<types::SafetySettings>) {
+        self.body.safety_settings = safety_settings;
+    }
+
     pub fn system_instruction(&mut self, instruction: &str) {
         self.body.system_instruction = Some(types::SystemInstructionContent {
             parts: vec![types::SystemInstructionPart {

--- a/src/types.rs
+++ b/src/types.rs
@@ -207,7 +207,7 @@ pub enum FinishReason {
     ImageSafety,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HarmCategory {
     HarmCategoryUnspecified,
@@ -224,7 +224,7 @@ pub enum HarmCategory {
     HarmCategoryCivicIntegrity,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HarmBlockThreshold {
     BlockNone,
@@ -298,7 +298,7 @@ pub struct GenerationConfig {
     pub response_schema: Option<Schema>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SafetySettings {
     pub category: HarmCategory,
     pub threshold: HarmBlockThreshold,


### PR DESCRIPTION
SafetySettings types exist. But there is is no way to actually set/use them. This pull request attempts to fix just that.